### PR TITLE
Travis CI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: python
+
+python:
+ - "2.7"
+ - "3.4"
+ - "3.5"
+ - "nightly"
+ - "pypy"
+ - "pypy3"
+
+matrix:
+  allow_failures:
+    # those "upcoming" python versions are informational
+    - python: nightly
+    - python: "pypy"
+    - python: "pypy3"
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - gfortran
+      - libfftw3-dev
+
+script:
+  ########################################################
+  # build
+  - make gfortran FFTI=/usr/include
+  # install?
+  # run example?

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # CHIMERA: a code for FEL and laser plasma simulations
 
+[![Build Status master](https://img.shields.io/travis/hightower8083/chimera/master.svg?label=master)](https://travis-ci.org/hightower8083/chimera/branches)
+[![Build Status dev](https://img.shields.io/travis/hightower8083/chimera/dev.svg?label=dev)](https://travis-ci.org/hightower8083/chimera/branches)
+
 by Igor A Andriyash (<igor.andriyash@gmail.com>)
 
 CHIMERA is a relativistic electromagnetic particle-in-cell code, based on a quasi-cylindric pseudo-spectral analytical time domain (PSATD) Maxwell solver.


### PR DESCRIPTION
I added a `.travis.yml` file that can be used to run the free [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) service [Travis CI](http://travis-ci.org/).

Just [log in](http://travis-ci.org/) with your GitHub account and enable testing for your repo: every new push and pull request will be checked with the instructions put in the `.travis.yml` ([here](https://travis-ci.org/ax3l/chimera/builds/170252955) is an example).

Currently, it's testing on [Ubuntu 12.04](https://docs.travis-ci.com/user/ci-environment/) and checks if Python 2.7, 3.4 & 3.5 building fine (`make gfortran`). Additionally, it tests against upcoming versions of python for purely informational purposes.

Maybe you want to add a small run time test, too? (1 core, 1min?)
Or testing for [OSX](https://docs.travis-ci.com/user/osx-ci-environment/)?

Feel free to merge & improve! :)
